### PR TITLE
Created iframe with a document.write rather than created natively in the 

### DIFF
--- a/background.html
+++ b/background.html
@@ -1,4 +1,4 @@
-<iframe id="frame"></iframe>
+
 <style>
   iframe {
     width: 440px;
@@ -10,6 +10,7 @@
     This used to be a fairly simple bit of code, but then I added
     stuff with very little forethought. Now it's a mess.
   */
+document.write('<iframe id="frame" src="http://images.google.com/?extension=ultimate&authuser='+(localStorage.auth_user||0)'></iframe>');
   var frame = document.getElementById('frame');
   
   


### PR DESCRIPTION
Created iframe with a document.write rather than created natively in the HTML due to a Rush Condition bug that exists in Chrome 13-14 that would make the extension not work after restart.
